### PR TITLE
Peaceful Werewolf Isle Resolution: Proper quest closure.

### DIFF
--- a/thecalling/dlg/werewolf.d
+++ b/thecalling/dlg/werewolf.d
@@ -191,8 +191,8 @@ END
 
 IF ~~ THEN BEGIN dielikedogs
 SAY @21647 
-IF ~~ THEN DO ~Enemy() ActionOverride("baresh",Enemy())~
-JOURNAL @21648 EXIT END
+  COPY_TRANS "%tutu_var%menda4" 5
+END
 
 IF ~~ THEN BEGIN nosailor
 SAY @21650
@@ -202,8 +202,15 @@ END
 
 IF ~~ THEN BEGIN wontliftgift
 SAY @21651
-IF ~~ THEN DO ~Enemy() ActionOverride("baresh",Enemy())~
-JOURNAL @21648 EXIT END
+  COPY_TRANS "%tutu_var%menda4" 3
+END
+END
+
+ALTER_TRANS "%tutu_var%menda4"
+BEGIN wontliftgift dielikedogs END
+BEGIN END	// Empty transaction list matches all.
+BEGIN
+  "JOURNAL" ~@21648~
 END
 
 REPLACE ~%tutu_var%baresh~


### PR DESCRIPTION
This fixes a bug that leaves the "The Reclusive Scholar" quest unresolved if the peaceful path is chosen, as discussed here:

https://www.gibberlings3.net/forums/topic/41376-bug-peaceful-resolution-to-werewolf-island-component-prevents-reclusive-scholar-quest-from-closing-successfully/

The fix uses COPY_TRANS in the alternative dialog states of Mendas/Selaad to (hopefully) further improve inter-mod compatibility.

NB: The same bug also exists in the SCS version of this component.  It is fixed in the same way in my fork of SCS, but I opted not to make a PR since DavidW is still missing, and he wouldn't accept it anyway.